### PR TITLE
Damage listener shouldn't listen on lowest priority

### DIFF
--- a/src/main/java/me/mrCookieSlime/MagicLoot/MLListener.java
+++ b/src/main/java/me/mrCookieSlime/MagicLoot/MLListener.java
@@ -84,7 +84,7 @@ public class MLListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
+	@EventHandler(ignoreCancelled=true)
 	public void onDamage(EntityDamageEvent e) {
 		
 		if (!(e.getEntity() instanceof LivingEntity)) return;


### PR DESCRIPTION
This fixes any conflicts with protection plugins and the like